### PR TITLE
Fix pygeohash missing get_adjacent method with current installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ Users have the flexibility to employ their custom graph or utilize OpenStreetMap
 You can easily install gpsmatcher using the Python package manager pip:
 
 ```bash
+# Once the package is available on PyPi:
 pip install gpsmatcher
+
+# For now, from Test PyPi:
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple gpsmatcher
+```
+
+gpsmatcher also depends on recent functionalities of pygeohash, not yet available on PyPi. Please install it directly from GitHub:
+
+```bash
+pip install 'git+https://github.com/wdm0006/pygeohash.git@a89e6e794f0dde4e066048ec16c867e945a680c1'
 ```
 
 ## Usage

--- a/gpsmatcher/precomputation_emission.py
+++ b/gpsmatcher/precomputation_emission.py
@@ -3,7 +3,20 @@ import os
 import networkx as nx
 import numpy as np
 import pandas as pd
-import pygeohash as pgh
+try:
+    import pygeohash as pgh
+except ImportError:
+    raise ImportError(
+        "The 'pygeohash' package is required for this module but is not installed.\n"
+        "Please install it directly from GitHub:\n"
+        "pip install 'git+https://github.com/wdm0006/pygeohash.git@a89e6e794f0dde4e066048ec16c867e945a680c1'"
+    )
+if not hasattr(pgh, 'get_adjacent'):
+    raise ImportError(
+        "The installed version of 'pygeohash' does not have the required 'get_adjacent' method.\n"
+        "Please install the correct version directly from GitHub:\n"
+        "pip install 'git+https://github.com/wdm0006/pygeohash.git@a89e6e794f0dde4e066048ec16c867e945a680c1'"
+    )
 import pygeohash_fast
 from gpsmatcher.utils import load_param, save_param
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ install_requires =
     numba
     networkx
     geopandas
-    pygeohash
     pygeohash_fast
     joblib
     scipy


### PR DESCRIPTION
gpsmatcher depends on the `get_adjacent` method from pygeohash. Unfortunately, this method is still not available in the last version published on PyPi, and PyPi does not allow to list direct dependency from GitHub.

To solve this problem, this pull request has:
- removed pygeohash from the dependency list, so it is not automatically installed by pip
- added instructions on the README file to install pygeohash directly from GitHub repository instead
- added checks to fail gracefully if the user did not follow the instructions